### PR TITLE
make default opt keyword list

### DIFF
--- a/lib/mqtt_potion/connection.ex
+++ b/lib/mqtt_potion/connection.ex
@@ -98,7 +98,7 @@ defmodule MqttPotion.Connection do
 
     ssl_opts =
       opts
-      |> Keyword.get(:ssl_opts, {})
+      |> Keyword.get(:ssl_opts, [])
       |> Keyword.put_new(:server_name_indication, String.to_charlist(opts[:host]))
 
     opts = Keyword.put(opts, :ssl_opts, ssl_opts)


### PR DESCRIPTION
If no SSL opt is passed the app failes to boot with this error

```elixir
** (Mix) Could not start application hub: Hub.Application.start(:normal, []) returned an error: shutdown: failed to start child: MqttPotion.Connection
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Keyword.put_new/3
            (elixir 1.12.3) lib/keyword.ex:646: Keyword.put_new({}, :server_name_indication, '127.0.0.1')
            (mqtt_potion 0.0.0) lib/mqtt_potion/connection.ex:102: MqttPotion.Connection.init/1
            (stdlib 3.16.1) gen_server.erl:423: :gen_server.init_it/2
            (stdlib 3.16.1) gen_server.erl:390: :gen_server.init_it/6
            (stdlib 3.16.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

`Keyword.put_new` cannot take an empty tuple. This PR makes the default value an empty keyword list.